### PR TITLE
Search Box Resetting After 50 Searches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.kdev4
+build
+kiten.kdev4

--- a/app/searchstringinput.cpp
+++ b/app/searchstringinput.cpp
@@ -137,7 +137,9 @@ void SearchStringInput::setSearchQuery( const DictQuery &query )
       copy.removeProperty("type");
   }
 
+  _actionTextInput->addToHistory(copy.toString()); // Update history and completion list
   _actionTextInput->setCurrentItem( copy.toString(), true );
+  _actionTextInput->reset(); // Call this manually when you call setCurrentItem
 }
 
 void SearchStringInput::test()


### PR DESCRIPTION
After reaching the maximum history count (about 50 by default), the combo box would remove the searched item and replace it with the last entry in the history. The fix is to add the last searched item to the history, set the item in the combo box, and reset the history to sync it.

reset() is required according to the KDE API Doc. http://api.kde.org/frameworks-api/frameworks5-apidocs/kcompletion/html/classKHistoryComboBox.html#af6ef37548be290c810e1603350393780
